### PR TITLE
Fixed responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .iml
 .DS_Store
+.nodemcutool

--- a/.nodemcutool
+++ b/.nodemcutool
@@ -1,0 +1,6 @@
+{
+    "baudrate": "9600",
+    "port": "com4",
+    "optimize": false,
+    "compile": false
+}

--- a/.nodemcutool
+++ b/.nodemcutool
@@ -1,6 +1,0 @@
-{
-    "baudrate": "9600",
-    "port": "com4",
-    "optimize": false,
-    "compile": false
-}

--- a/http_response_send.lua
+++ b/http_response_send.lua
@@ -3,8 +3,9 @@
 ------------------------------------------------------------------------------
 return function(res, data, status)
  local conn = res.conn
+ local buf
  --   write protocol headers
- conn:send("HTTP/1.1 " .. tostring(status or res.statuscode) .. " " .. dofile('http-' .. tostring(status or res.statuscode)) .. "\r\n")
+ buf="HTTP/1.1 " .. tostring(status or res.statuscode) .. " " .. dofile('http-' .. tostring(status or res.statuscode)) .. "\r\n"
  --   write response headers
  res:addheader("Server", "NodeMCU")
  if data then
@@ -12,14 +13,17 @@ return function(res, data, status)
  end
  for key, value in pairs(res.headers) do
   -- send header
-  res.conn:send(key .. ": " .. value .. "\r\n")
+  buf=buf .. key .. ": " .. value .. "\r\n"
  end
- conn:send("\r\n")
+ buf=buf.."\r\n"
  --   write body if relevant
  if data then
-  conn:send(data)
-  conn:send("\r\n")
+  buf=buf..data
+  buf=buf.."\r\n"
  end
+ -- send 
+ conn:send(buf)
+ buf=nil
  -- close connection
  conn:close()
 end

--- a/mime-types/type-ico
+++ b/mime-types/type-ico
@@ -1,0 +1,1 @@
+return "image/x-icon"

--- a/plugins/routes_auto.lua
+++ b/plugins/routes_auto.lua
@@ -8,6 +8,9 @@ local handler = function(req, res, next, opts)
  print("Request received: ", req.method, req.url)
  -- /api/myservice or /my-static-content.html
  local url = req.url
+ if url == "/" then
+    url = "/index.html"
+ end
  if url:sub(0, 4) == "/api" then
   -- [GET] /api/myservice will call routes/myservice.get.lc
   local filename = "routes" .. url:sub(5) .. "." .. req.method:lower() .. ".lc"

--- a/upload.cmd
+++ b/upload.cmd
@@ -1,0 +1,25 @@
+@call nodemcu-tool upload espress.lua --compile --optimize
+@call nodemcu-tool upload http_not_found.lua --compile --optimize
+@call nodemcu-tool upload http_request.lua --compile --optimize
+@call nodemcu-tool upload http_response_send.lua --compile --optimize
+@call nodemcu-tool upload http_response_sendfile.lua --compile --optimize
+@call nodemcu-tool upload http_response.lua --compile --optimize
+@call nodemcu-tool upload plugins/auth_api_key.lua --compile --optimize
+@call nodemcu-tool upload plugins/router.lua --compile --optimize
+@call nodemcu-tool upload plugins/routes_auto.lua --compile --optimize
+@call nodemcu-tool upload status-codes/http-200
+@call nodemcu-tool upload status-codes/http-400
+@call nodemcu-tool upload status-codes/http-401
+@call nodemcu-tool upload status-codes/http-403
+@call nodemcu-tool upload status-codes/http-404
+@call nodemcu-tool upload status-codes/http-405
+@call nodemcu-tool upload status-codes/http-503
+@call nodemcu-tool upload mime-types/type-css
+@call nodemcu-tool upload mime-types/type-html
+@call nodemcu-tool upload mime-types/type-jpg
+@call nodemcu-tool upload mime-types/type-js
+@call nodemcu-tool upload mime-types/type-json
+@call nodemcu-tool upload mime-types/type-png
+@call nodemcu-tool upload mime-types/type-ico
+
+pause


### PR DESCRIPTION
When using the current LUA firmwares, a complete set of headers should be sent via a socket in one call. I fixed this in http_response_send and http_response_sendfile

Also, new data should only be sent after the firmware has triggered a 'sent' event for the socket. I fixed this for http_response_sendfile

I also added the mime-type for .ICO files
